### PR TITLE
Curiousity Pass

### DIFF
--- a/DisplaySpellTomeLevelPatcher/DisplaySpellTomeLevelPatcher.csproj
+++ b/DisplaySpellTomeLevelPatcher/DisplaySpellTomeLevelPatcher.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+      <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     </PropertyGroup>
     <ItemGroup>
       <Compile Remove="Data\**" />

--- a/DisplaySpellTomeLevelPatcher/Program.cs
+++ b/DisplaySpellTomeLevelPatcher/Program.cs
@@ -68,6 +68,14 @@ namespace DisplaySpellTomeLevelPatcher
             return scrollSpellName;
         }
 
+        public static bool NamedFieldsContain<TMajor>(TMajor named, string str)
+            where TMajor : INamedGetter, IMajorRecordCommonGetter
+        {
+            if (named.EditorID?.Contains(str) ?? false) return true;
+            if (named.Name?.Contains(str) ?? false) return true;
+            return false;
+        }
+
         public static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
             foreach (var book in state.LoadOrder.PriorityOrder.Book().WinningOverrides())
@@ -90,11 +98,7 @@ namespace DisplaySpellTomeLevelPatcher
 
                 foreach (string skillLevel in skillLevels)
                 {
-                    if ((!halfCostPerk.Name?.String?.Contains(skillLevel) ?? true)
-                        && (!halfCostPerk.EditorID?.Contains(skillLevel) ?? true))
-                    {
-                        continue;
-                    }
+                    if (!NamedFieldsContain(halfCostPerk, skillLevel)) continue;
 
                     System.Console.WriteLine($"{book.FormKey}: Registering {spellName} as {skillLevel}");
                     spellLevelDictionary[spellName] = skillLevel;

--- a/DisplaySpellTomeLevelPatcher/Program.cs
+++ b/DisplaySpellTomeLevelPatcher/Program.cs
@@ -97,10 +97,11 @@ namespace DisplaySpellTomeLevelPatcher
                     }
 
                     System.Console.WriteLine($"{book.FormKey}: Registering {spellName} as {skillLevel}");
+                    spellLevelDictionary[spellName] = skillLevel;
+
                     string generatedName = GenerateSpellTomeName(book.Name.String, skillLevel);
                     if (generatedName == book.Name.String) continue;
 
-                    spellLevelDictionary[spellName] = skillLevel;
                     Book bookToAdd = book.DeepCopy();
                     bookToAdd.Name = generatedName;
                     state.PatchMod.Books.Set(bookToAdd);


### PR DESCRIPTION
Only actual logic change should be:
- Moved spellLevelDictionary registration to before ITM short circuit 

Wouldn't affect the non-scroll setup.

-------------------------------------

Aside from that, just did a collapse of the if statements.  I find it more readable (but feel free to veto! haha)
Added some logging to hopefully help debug for the next time

Couldn't find anything that looked weird to me.    Not sure how a master could've gotten assigned if SOME halfCostPerk didn't have it as its name.  Weird